### PR TITLE
Remove newlines from stream name

### DIFF
--- a/Auto_Recording_Twitch.py
+++ b/Auto_Recording_Twitch.py
@@ -159,10 +159,10 @@ class TwitchRecorder:
                 recorded_filename = os.path.join(self.recorded_path, f)
                 if self.short_folder == 1:
                     dirname = f[shorta:shortb]
-                    dirname = "".join(x for x in dirname if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|"])
+                    dirname = "".join(x for x in dirname if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|","\n"])
                 else:
                     dirname = f[longa:longb] + f[longc:-4]
-                    dirname = "".join(x for x in dirname if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|"])
+                    dirname = "".join(x for x in dirname if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|","\n"])
 
                 if self.make_stream_folder == 1:
                     stream_dir_path = self.processed_path + '/' + dirname
@@ -283,7 +283,7 @@ class TwitchRecorder:
                 time.sleep(self.refresh)
             elif status == 0:
                 stream_title = str(info['status'])
-                stream_title = "".join(x for x in stream_title if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|"])
+                stream_title = "".join(x for x in stream_title if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|","\n"])
 
                 present_date     = datetime.datetime.now().strftime("%Y%m%d")
                 present_datetime = datetime.datetime.now().strftime("%Y%m%d_%Hh%Mm%Ss")
@@ -291,7 +291,7 @@ class TwitchRecorder:
                 filename = present_datetime + "_" + stream_title + '_' + str(info['game']) + "_" + self.username + ".mp4"
 
                 # clean filename from unecessary characters
-                filename = "".join(x for x in filename if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|"])
+                filename = "".join(x for x in filename if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|","\n"])
 
                 recorded_filename = os.path.join(self.recorded_path, filename)
 
@@ -303,7 +303,7 @@ class TwitchRecorder:
                     else:
                         stream_title      = stream_title[:difference]
                         filename          = present_datetime + "_" + stream_title + '_' + str(info['game']) + "_" + self.username + ".mp4"
-                        filename          = "".join(x for x in filename if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|"])
+                        filename          = "".join(x for x in filename if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|","\n"])
                         recorded_filename = os.path.join(self.recorded_path, filename)
 
                 # start streamlink process
@@ -341,7 +341,7 @@ class TwitchRecorder:
                                 vod_id = vod_id[1:]
 
                                 stream_title = str(vodsinfodic["videos"][0]["title"])
-                                stream_title = "".join(x for x in stream_title if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|"])
+                                stream_title = "".join(x for x in stream_title if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|","\n"])
 
                                 created_at = vodsinfodic["videos"][0]["created_at"]
 
@@ -358,7 +358,7 @@ class TwitchRecorder:
                                     processed_stream_folder = vod_date_tz.strftime("%Y%m%d")
                                 else:
                                     processed_stream_folder = vod_date_tz.strftime("%Y%m%d") + "_" + stream_title + '_' + vodsinfodic["videos"][0]["game"] + '_' + self.username
-                                    processed_stream_folder = "".join(x for x in processed_stream_folder if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|"])
+                                    processed_stream_folder = "".join(x for x in processed_stream_folder if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|","\n"])
 
                                 if self.make_stream_folder == 1:
                                     processed_stream_path = self.processed_path + "/" + processed_stream_folder
@@ -366,7 +366,7 @@ class TwitchRecorder:
                                     processed_stream_path = self.processed_path
 
                                 filename = vod_date_tz.strftime("%Y%m%d_(%H-%M)") + "_" + vod_id + "_" + stream_title + '_' + vodsinfodic["videos"][0]["game"] + '_' + self.username + ".mp4"
-                                filename = "".join(x for x in filename if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|"])
+                                filename = "".join(x for x in filename if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|","\n"])
 
                                 if len(os.path.join(self.recorded_path, filename)) >= 260:
                                     difference = len(stream_title) - len(os.path.join(self.recorded_path, filename)) + 250
@@ -382,7 +382,7 @@ class TwitchRecorder:
                                         stream_title = stream_title[:difference]
 
                                         filename = vod_date_tz.strftime("%Y%m%d_(%H-%M)") + "_" + vod_id + "_" + stream_title + '_' + vodsinfodic["videos"][0]["game"] + '_' + self.username + ".mp4"
-                                        filename = "".join(x for x in filename if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|"])
+                                        filename = "".join(x for x in filename if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|","\n"])
                                         if self.warning_windows == 1:
                                             if self.osCheck == 0:
                                                 subprocess.call(self.main_cmd_window + ['echo', 'Path to stream is too long. (Max path length is 259 symbols) Title will be cropped, please check root path.'])
@@ -408,13 +408,13 @@ class TwitchRecorder:
                                         stream_title = stream_title[:difference]
 
                                         filename = vod_date_tz.strftime("%Y%m%d_(%H-%M)") + "_" + vod_id + "_" + stream_title + '_' + vodsinfodic["videos"][0]["game"] + '_' + self.username + ".mp4"
-                                        filename = "".join(x for x in filename if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|"])
+                                        filename = "".join(x for x in filename if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|","\n"])
 
                                         if self.short_folder == 1:
                                             processed_stream_folder = vod_date_tz.strftime("%Y%m%d")
                                         else:
                                             processed_stream_folder = vod_date_tz.strftime("%Y%m%d") + "_" + stream_title + '_' + vodsinfodic["videos"][0]["game"] + '_' + self.username
-                                            processed_stream_folder = "".join(x for x in processed_stream_folder if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|"])
+                                            processed_stream_folder = "".join(x for x in processed_stream_folder if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|","\n"])
 
                                         if self.make_stream_folder == 1:
                                             processed_stream_path = self.processed_path + "/" + processed_stream_folder
@@ -438,17 +438,17 @@ class TwitchRecorder:
                                     processed_filename = os.path.join(processed_stream_path, filename)
                                 except Exception as e:
                                     stream_title = str(info['status'])
-                                    stream_title = "".join(x for x in stream_title if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|"])
+                                    stream_title = "".join(x for x in stream_title if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|","\n"])
 
                                     filename = present_datetime + "_" + stream_title + '_' + str(info['game']) + "_" + self.username + ".mp4"
-                                    filename = "".join(x for x in filename if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|"])
+                                    filename = "".join(x for x in filename if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|","\n"])
 
                                     if self.short_folder == 1:
                                         processed_stream_folder = present_date
-                                        processed_stream_folder = "".join(x for x in processed_stream_folder if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|"])
+                                        processed_stream_folder = "".join(x for x in processed_stream_folder if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|","\n"])
                                     else:
                                         processed_stream_folder = present_date + "_" + stream_title + '_' + str(info['game']) + "_" + self.username
-                                        processed_stream_folder = "".join(x for x in processed_stream_folder if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|"])
+                                        processed_stream_folder = "".join(x for x in processed_stream_folder if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|","\n"])
 
                                     if self.make_stream_folder == 1:
                                         processed_stream_path = self.processed_path + "/" + processed_stream_folder
@@ -473,13 +473,13 @@ class TwitchRecorder:
                                             stream_title = stream_title[:difference]
 
                                             filename = present_datetime + "_" + stream_title + '_' + str(info['game']) + "_" + self.username + ".mp4"
-                                            filename = "".join(x for x in filename if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|"])
+                                            filename = "".join(x for x in filename if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|","\n"])
 
                                             if self.short_folder == 1:
                                                 processed_stream_folder = present_date
                                             else:
                                                 processed_stream_folder = present_date + "_" + stream_title + '_' + str(info['game']) + "_" + self.username
-                                                processed_stream_folder = "".join(x for x in processed_stream_folder if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|"])
+                                                processed_stream_folder = "".join(x for x in processed_stream_folder if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|","\n"])
 
                                             if self.make_stream_folder == 1:
                                                 processed_stream_path = self.processed_path + "/" + processed_stream_folder
@@ -528,16 +528,16 @@ class TwitchRecorder:
                                             subprocess.call(' '.join(self.main_cmd_window + ['bash', '-c', "'streamlink", "--hls-segment-threads", str(self.hls_segmentsVOD), "twitch.tv/videos/" + vod_id, self.quality] + self.debug_cmd + ["-o", '"' + os.path.join(self.recorded_path, vod_filename) + '"' + self.linuxstatecomma]), shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
                             else:
                                 stream_title = str(info['status'])
-                                stream_title = "".join(x for x in stream_title if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|"])
+                                stream_title = "".join(x for x in stream_title if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|","\n"])
 
                                 filename = present_datetime + "_" + stream_title + '_' + str(info['game']) + "_" + self.username + ".mp4"
-                                filename = "".join(x for x in filename if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|"])
+                                filename = "".join(x for x in filename if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|","\n"])
 
                                 if self.short_folder == 1:
                                     processed_stream_folder = present_date
                                 else:
                                     processed_stream_folder = present_date + "_" + stream_title + '_' + str(info['game']) + "_" + self.username
-                                    processed_stream_folder = "".join(x for x in processed_stream_folder if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|"])
+                                    processed_stream_folder = "".join(x for x in processed_stream_folder if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|","\n"])
 
                                 if self.make_stream_folder == 1:
                                     processed_stream_path = self.processed_path + "/" + processed_stream_folder
@@ -562,13 +562,13 @@ class TwitchRecorder:
                                         stream_title = stream_title[:difference]
 
                                         filename = present_datetime + "_" + stream_title + '_' + str(info['game']) + "_" + self.username + ".mp4"
-                                        filename = "".join(x for x in filename if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|"])
+                                        filename = "".join(x for x in filename if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|","\n"])
 
                                         if self.short_folder == 1:
                                             processed_stream_folder = present_date
                                         else:
                                             processed_stream_folder = present_date + "_" + stream_title + '_' + str(info['game']) + "_" + self.username
-                                            processed_stream_folder = "".join(x for x in processed_stream_folder if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|"])
+                                            processed_stream_folder = "".join(x for x in processed_stream_folder if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|","\n"])
 
                                         if self.make_stream_folder == 1:
                                             processed_stream_path = self.processed_path + "/" + processed_stream_folder
@@ -584,16 +584,16 @@ class TwitchRecorder:
 
                         except Exception as e:
                             stream_title = str(info['status'])
-                            stream_title = "".join(x for x in stream_title if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|"])
+                            stream_title = "".join(x for x in stream_title if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|","\n"])
 
                             filename = present_datetime + "_" + stream_title + '_' + str(info['game']) + "_" + self.username + ".mp4"
-                            filename = "".join(x for x in filename if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|"])
+                            filename = "".join(x for x in filename if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|","\n"])
 
                             if self.short_folder == 1:
                                 processed_stream_folder = present_date
                             else:
                                 processed_stream_folder = present_date + "_" + stream_title + '_' + str(info['game']) + "_" + self.username
-                                processed_stream_folder = "".join(x for x in processed_stream_folder if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|"])
+                                processed_stream_folder = "".join(x for x in processed_stream_folder if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|","\n"])
 
                             if self.make_stream_folder == 1:
                                 processed_stream_path = self.processed_path + "/" + processed_stream_folder
@@ -618,13 +618,13 @@ class TwitchRecorder:
                                     stream_title = stream_title[:difference]
 
                                     filename = present_datetime + "_" + stream_title + '_' + str(info['game']) + "_" + self.username + ".mp4"
-                                    filename = "".join(x for x in filename if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|"])
+                                    filename = "".join(x for x in filename if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|","\n"])
 
                                     if self.short_folder == 1:
                                         processed_stream_folder = present_date
                                     else:
                                         processed_stream_folder = present_date + "_" + stream_title + '_' + str(info['game']) + "_" + self.username
-                                        processed_stream_folder = "".join(x for x in processed_stream_folder if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|"])
+                                        processed_stream_folder = "".join(x for x in processed_stream_folder if x.isalnum() or not x in ["/","\\",":","?","*",'"',">","<","|","\n"])
 
                                     if self.make_stream_folder == 1:
                                         processed_stream_path = self.processed_path + "/" + processed_stream_folder


### PR DESCRIPTION
Some stream titles seem to contain newline characters ('\n') for some reason. This causes the script to fail with 'error: Failed to open output'.
Adding the newline character to the list of characters to remove fixes this.